### PR TITLE
Add "CommandLine.h" header for cli support

### DIFF
--- a/src/BogusFlow.cpp
+++ b/src/BogusFlow.cpp
@@ -4,6 +4,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
 #include "llvm/Transforms/Utils/Cloning.h"
+#include "llvm/Support/CommandLine.h"
 
 #include <random>
 

--- a/src/Substitution.cpp
+++ b/src/Substitution.cpp
@@ -3,6 +3,7 @@
 #include "llvm/IR/InstrTypes.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/Pass.h"
+#include "llvm/Support/CommandLine.h"
 
 #include <random>
 


### PR DESCRIPTION
Missing the header may cause compile error